### PR TITLE
Reduce overhead by casting result

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivebus/library/ReactiveBus.java
+++ b/library/src/main/java/com/github/pwittchen/reactivebus/library/ReactiveBus.java
@@ -24,7 +24,7 @@ import io.reactivex.subjects.Subject;
 
 public class ReactiveBus implements Bus {
 
-  private Subject<Object> bus = PublishSubject.create().toSerialized();
+  private final Subject<Object> bus = PublishSubject.create().toSerialized();
 
   public static ReactiveBus create() {
     return new ReactiveBus();
@@ -36,19 +36,14 @@ public class ReactiveBus implements Bus {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Flowable<Event> receive() {
-    return bus
+    return (Flowable<Event>)(Flowable<?>) bus
         .toFlowable(BackpressureStrategy.BUFFER)
         .filter(new Predicate<Object>() {
           @Override
           public boolean test(final Object o) {
             return o instanceof Event;
-          }
-        })
-        .map(new Function<Object, Event>() {
-          @Override
-          public Event apply(final Object object) {
-            return (Event) object;
           }
         });
   }

--- a/library/src/main/java/com/github/pwittchen/reactivebus/library/ReactiveBus.java
+++ b/library/src/main/java/com/github/pwittchen/reactivebus/library/ReactiveBus.java
@@ -17,7 +17,6 @@ package com.github.pwittchen.reactivebus.library;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.Subject;
@@ -38,7 +37,7 @@ public class ReactiveBus implements Bus {
   @Override
   @SuppressWarnings("unchecked")
   public Flowable<Event> receive() {
-    return (Flowable<Event>)(Flowable<?>) bus
+    return (Flowable<Event>) (Flowable<?>) bus
         .toFlowable(BackpressureStrategy.BUFFER)
         .filter(new Predicate<Object>() {
           @Override


### PR DESCRIPTION
Library is really tiny (a testament to the power of RxJava) but I thought I'd make a PR to reduce overhead for you. 

By the time the filter has occurred you know exactly what type the stream is so you can just use a cast instead.